### PR TITLE
feat(robotwin eval): rewrite robotwin benchmark scripts

### DIFF
--- a/experiment/robotwin/README.md
+++ b/experiment/robotwin/README.md
@@ -93,3 +93,108 @@ Output:
 ```
 ${XDG_CACHE_HOME}/huggingface/lerobot/${repo_id}
 ```
+
+---
+
+## 7. Simulated Evaluation (Inference + RoboTwin Sim)
+
+After training, evaluate your checkpoint on the 50 RoboTwin tasks (100 episodes each) with
+[`start_robotwin_infer_and_eval.sh`](./start_robotwin_infer_and_eval.sh). It starts
+`num_gpus * num_per_gpu` resident inference servers (one port each), then runs the sim tasks
+in a **queue-scheduled** fashion against free slots — finishing a task frees its slot and
+starts the next. All flags below also accept the equivalent environment variable
+(`MODEL_PATH`, `EVAL_WORKDIR`, `OUTPUT_BASE`, `CONDA_SH`, `QWEN3VL_PATH`, `INFERENCE_ENV`, `SIM_ENV`).
+
+### Prerequisites
+
+1. **RoboTwin repo** cloned and its dependencies installed (steps 1–2 above). The launcher
+   needs the repo **root** path (the one containing `envs/`, `assets/`, `task_config/`, `script/`).
+2. **Two conda environments**:
+   - inference side — e.g. `lingbotvla` (PyTorch + this repo's model code).
+   - sim side — `RoboTwin` (sapien / mplib / curobo / open3d …), built against numpy 1.26.x.
+3. **Qwen3-VL backbone** checkpoint used by the VLA vision-language encoder (`QWEN3VL_PATH`).
+4. **Your trained HF checkpoint** (`model_path`), e.g. `.../global_step_xxxxx/hf_ckpt`.
+
+> The launcher **auto-copies** the eval client (`eval_policy_client_lingbotvla.py` + the small
+> `deploy/` helpers) from this repo into `<RoboTwin>/script/`, and **self-heals** the curobo
+> embodiment `.yml` and editable-install `.pth` paths to point at the RoboTwin checkout you
+> pass. No manual path setup is needed when relocating RoboTwin.
+
+### Run the full benchmark (50 tasks)
+
+> Substitute every `/path/to/...` and the conda env / `conda.sh` path for your machine.
+
+```bash
+# from this repo's root (so inference_workdir = current working dir)
+bash experiment/robotwin/start_robotwin_infer_and_eval.sh \
+    --model_path     /path/to/your/checkpoint/hf_ckpt \
+    --eval_workdir   /path/to/RoboTwin \
+    --output_base    /path/to/VLABenchmarkResult \
+    --conda_sh       /path/to/miniconda3/etc/profile.d/conda.sh \
+    --inference_env  lingbotvla \
+    --sim_env        RoboTwin \
+    --num_tasks 50 --num_gpus 4 --num_per_gpu 1
+```
+
+**GPU / concurrency**
+- `num_gpus` × `num_per_gpu` = number of concurrent sim slots (one inference server per slot).
+- `--num_per_gpu 1` is the **safe** default: one ~12.6 GB Qwen3-VL server + one sim per 32 GB card.
+- `--num_per_gpu 2` roughly halves wall-clock but is memory-tight and can OOM on 32 GB cards
+  (the script retries each task up to 3 times, but persistent OOM skips the task).
+
+### Smoke test (1 task, 1 GPU)
+
+Verify the pipeline end-to-end without waiting for the full run:
+
+```bash
+bash experiment/robotwin/start_robotwin_infer_and_eval.sh \
+    --model_path   /path/to/your/checkpoint/hf_ckpt \
+    --eval_workdir /path/to/RoboTwin \
+    --conda_sh     /path/to/miniconda3/etc/profile.d/conda.sh \
+    --num_tasks 1 --num_gpus 1 --num_per_gpu 1
+```
+
+The run dir is printed at startup (`Run directory: ...`). You should see `Success rate: N/N =>
+...` lines appear in the task log. Each task evaluates **100 episodes**, so even a
+single-task smoke takes tens of minutes — kill it once you've seen successes, then launch
+the full run.
+
+### Output layout
+
+```
+<output_base>/<exp>_<step>k_<timestamp>/
+├── stats.txt                 # final per-task table + overall success rate
+├── inference_logs/           # one log per inference server / port
+├── eval_logs/                # one log per task (per-step progress, success rate)
+└── eval_results/             # per-task videos: episodeN_success.mp4 ...
+```
+
+### Useful flags
+
+| flag | meaning |
+|------|---------|
+| `--no_video` | disable per-episode video recording (faster, no videos saved) |
+| `--keep_inference` | leave inference servers resident after sim finishes |
+| `--start_port` | base port for inference servers (default 9330, slot *i* uses base + i) |
+| `--use_length` | action-chunk length forwarded to the policy (default 50) |
+| `--robo_name` | robot config name (default `robotwin`) |
+| `--inference_script` | inference-side module (default `deploy/lingbot_vla_v2_policy.py`) |
+
+### Monitor / stop
+
+```bash
+RUN=/path/to/VLABenchmarkResult/<exp>_<step>k_<timestamp>
+
+# overall progress (done/skip/fail summary)
+sed 's/\x1b\[[0-9;]*m//g' $RUN/eval_logs/*.log | grep -E "Success rate" | tail
+
+# per-task latest success rate
+for f in $RUN/eval_logs/*.log; do
+  printf "%-24s %s\n" "$(basename $f .log)" \
+    "$(grep -aoE 'Success rate: [0-9]+/[0-9]+ => [0-9.]+%' "$f" | tail -1)"
+done
+```
+
+Stop everything with `Ctrl-C` (the launcher traps it and kills all child processes), or kill
+the launcher plus any lingering `deploy.lingbot_vla_v2_policy` / `eval_policy_client_lingbotvla.py`
+processes.

--- a/experiment/robotwin/eval_policy_client_lingbotvla.py
+++ b/experiment/robotwin/eval_policy_client_lingbotvla.py
@@ -1,0 +1,437 @@
+import sys
+import os
+import subprocess
+
+sys.path.append("./")
+sys.path.append(f"./policy")
+sys.path.append("./description/utils")
+from envs import CONFIGS_PATH
+from envs.utils.create_actor import UnStableError
+
+import numpy as np
+from pathlib import Path
+from collections import deque
+import traceback
+
+import yaml
+from datetime import datetime
+import importlib
+import argparse
+import pdb
+
+from generate_episode_instructions import *
+
+current_file_path = os.path.abspath(__file__)
+parent_directory = os.path.dirname(current_file_path)
+
+
+def class_decorator(task_name):
+    envs_module = importlib.import_module(f"envs.{task_name}")
+    try:
+        env_class = getattr(envs_module, task_name)
+        env_instance = env_class()
+    except:
+        raise SystemExit("No Task")
+    return env_instance
+
+
+def eval_function_decorator(policy_name, model_name):
+    try:
+        policy_model = importlib.import_module(policy_name)
+        return getattr(policy_model, model_name)
+    except ImportError as e:
+        raise e
+
+def get_camera_config(camera_type):
+    camera_config_path = os.path.join(parent_directory, "../task_config/_camera_config.yml")
+
+    assert os.path.isfile(camera_config_path), "task config file is missing"
+
+    with open(camera_config_path, "r", encoding="utf-8") as f:
+        args = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    assert camera_type in args, f"camera {camera_type} is not defined"
+    return args[camera_type]
+
+
+def get_embodiment_config(robot_file):
+    robot_config_file = os.path.join(robot_file, "config.yml")
+    with open(robot_config_file, "r", encoding="utf-8") as f:
+        embodiment_args = yaml.load(f.read(), Loader=yaml.FullLoader)
+    return embodiment_args
+
+
+def main(usr_args):
+    current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    task_name = usr_args["task_name"]
+    task_config = usr_args["task_config"]
+    ckpt_setting = usr_args["ckpt_setting"]
+    # checkpoint_num = usr_args['checkpoint_num']
+    policy_name = usr_args["policy_name"]
+    instruction_type = usr_args["instruction_type"]
+    save_dir = None
+    video_save_dir = None
+    video_size = None
+    video_fps = str(usr_args.get("video_fps", 10))
+
+    get_model = eval_function_decorator(policy_name, "get_model")
+
+    with open(f"./task_config/{task_config}.yml", "r", encoding="utf-8") as f:
+        args = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    args['task_name'] = task_name
+    args["task_config"] = task_config
+    args["ckpt_setting"] = ckpt_setting
+
+    embodiment_type = args.get("embodiment")
+    embodiment_config_path = os.path.join(CONFIGS_PATH, "_embodiment_config.yml")
+
+    with open(embodiment_config_path, "r", encoding="utf-8") as f:
+        _embodiment_types = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    def get_embodiment_file(embodiment_type):
+        robot_file = _embodiment_types[embodiment_type]["file_path"]
+        if robot_file is None:
+            raise "No embodiment files"
+        return robot_file
+
+    with open(CONFIGS_PATH + "_camera_config.yml", "r", encoding="utf-8") as f:
+        _camera_config = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    head_camera_type = args["camera"]["head_camera_type"]
+    args["head_camera_h"] = _camera_config[head_camera_type]["h"]
+    args["head_camera_w"] = _camera_config[head_camera_type]["w"]
+
+    if len(embodiment_type) == 1:
+        args["left_robot_file"] = get_embodiment_file(embodiment_type[0])
+        args["right_robot_file"] = get_embodiment_file(embodiment_type[0])
+        args["dual_arm_embodied"] = True
+    elif len(embodiment_type) == 3:
+        args["left_robot_file"] = get_embodiment_file(embodiment_type[0])
+        args["right_robot_file"] = get_embodiment_file(embodiment_type[1])
+        args["embodiment_dis"] = embodiment_type[2]
+        args["dual_arm_embodied"] = False
+    else:
+        raise "embodiment items should be 1 or 3"
+
+    args["left_embodiment_config"] = get_embodiment_config(args["left_robot_file"])
+    args["right_embodiment_config"] = get_embodiment_config(args["right_robot_file"])
+
+    if len(embodiment_type) == 1:
+        embodiment_name = str(embodiment_type[0])
+    else:
+        embodiment_name = str(embodiment_type[0]) + "+" + str(embodiment_type[1])
+
+    if usr_args.get("output_dir"):
+        save_dir = Path(usr_args["output_dir"]) / task_name
+    else:
+        save_dir = Path(f"eval_result/{task_name}/{policy_name}/{task_config}/{ckpt_setting}/{current_time}")
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    # 命令行 --eval_video_log 优先于 YAML 配置
+    if "eval_video_log" in usr_args:
+        args["eval_video_log"] = usr_args["eval_video_log"]
+
+    if args["eval_video_log"]:
+        video_save_dir = save_dir
+        camera_config = get_camera_config(args["camera"]["head_camera_type"])
+        video_size = str(camera_config["w"]) + "x" + str(camera_config["h"])
+        video_save_dir.mkdir(parents=True, exist_ok=True)
+        args["eval_video_save_dir"] = video_save_dir
+
+    # output camera config
+    print("============= Config =============\n")
+    print("\033[95mMessy Table:\033[0m " + str(args["domain_randomization"]["cluttered_table"]))
+    print("\033[95mRandom Background:\033[0m " + str(args["domain_randomization"]["random_background"]))
+    if args["domain_randomization"]["random_background"]:
+        print(" - Clean Background Rate: " + str(args["domain_randomization"]["clean_background_rate"]))
+    print("\033[95mRandom Light:\033[0m " + str(args["domain_randomization"]["random_light"]))
+    if args["domain_randomization"]["random_light"]:
+        print(" - Crazy Random Light Rate: " + str(args["domain_randomization"]["crazy_random_light_rate"]))
+    print("\033[95mRandom Table Height:\033[0m " + str(args["domain_randomization"]["random_table_height"]))
+    print("\033[95mRandom Head Camera Distance:\033[0m " + str(args["domain_randomization"]["random_head_camera_dis"]))
+
+    print("\033[94mHead Camera Config:\033[0m " + str(args["camera"]["head_camera_type"]) + f", " +
+          str(args["camera"]["collect_head_camera"]))
+    print("\033[94mWrist Camera Config:\033[0m " + str(args["camera"]["wrist_camera_type"]) + f", " +
+          str(args["camera"]["collect_wrist_camera"]))
+    print("\033[94mEmbodiment Config:\033[0m " + embodiment_name)
+    print("\n==================================")
+
+    TASK_ENV = class_decorator(args["task_name"])
+    args["policy_name"] = policy_name
+    usr_args["left_arm_dim"] = len(args["left_embodiment_config"]["arm_joints_name"][0])
+    usr_args["right_arm_dim"] = len(args["right_embodiment_config"]["arm_joints_name"][1])
+
+    seed = usr_args["seed"]
+
+    st_seed = 100000 * (1 + seed)
+    suc_nums = []
+    test_num = 100
+    topk = 1
+
+    # model = get_model(usr_args)
+    # from IPython import embed;embed()
+    from script.deploy.websocket_client_policy import WebsocketClientPolicy
+    model = WebsocketClientPolicy(port=usr_args['port'])
+
+    st_seed, suc_num = eval_policy(task_name,
+                                   TASK_ENV,
+                                   args,
+                                   model,
+                                   st_seed,
+                                   test_num=test_num,
+                                   video_size=video_size,
+                                   video_fps=video_fps,
+                                   instruction_type=instruction_type,
+                                   usr_args=usr_args)
+    suc_nums.append(suc_num)
+
+    topk_success_rate = sorted(suc_nums, reverse=True)[:topk]
+
+    file_path = os.path.join(save_dir, f"_result.txt")
+    with open(file_path, "w") as file:
+        file.write(f"Timestamp: {current_time}\n\n")
+        file.write(f"Instruction Type: {instruction_type}\n\n")
+        # file.write(str(task_reward) + '\n')
+        file.write("\n".join(map(str, np.array(suc_nums) / test_num)))
+
+    print(f"Data has been saved to {file_path}")
+    # return task_reward
+
+
+def eval_policy(task_name,
+                TASK_ENV,
+                args,
+                model,
+                st_seed,
+                test_num=100,
+                video_size=None,
+                video_fps="10",
+                instruction_type=None,
+                usr_args = None):
+    print(f"\033[34mTask Name: {args['task_name']}\033[0m")
+    print(f"\033[34mPolicy Name: {args['policy_name']}\033[0m")
+
+    expert_check = True
+    TASK_ENV.suc = 0
+    TASK_ENV.test_num = 0
+
+    now_id = 0
+    succ_seed = 0
+    suc_test_seed_list = []
+
+    policy_name = args["policy_name"]
+    # eval_func = eval_function_decorator(policy_name, "eval")
+    # reset_func = eval_function_decorator(policy_name, "reset_model")
+
+    now_seed = st_seed
+    task_total_reward = 0
+    clear_cache_freq = args["clear_cache_freq"]
+
+    args["eval_mode"] = True
+
+    while succ_seed < test_num:
+        render_freq = args["render_freq"]
+        args["render_freq"] = 0
+
+        if expert_check:
+            try:
+                TASK_ENV.setup_demo(now_ep_num=now_id, seed=now_seed, is_test=True, **args)
+                episode_info = TASK_ENV.play_once()
+                TASK_ENV.close_env()
+            except UnStableError as e:
+                # print(" -------------")
+                # print("Error: ", e)
+                # print(" -------------")
+                TASK_ENV.close_env()
+                now_seed += 1
+                args["render_freq"] = render_freq
+                continue
+            except Exception as e:
+                # stack_trace = traceback.format_exc()
+                # print(" -------------")
+                # print("Error: ", e)
+                # print(" -------------")
+                TASK_ENV.close_env()
+                now_seed += 1
+                args["render_freq"] = render_freq
+                print(f"error occurs ! {e}")
+                continue
+
+        if (not expert_check) or (TASK_ENV.plan_success and TASK_ENV.check_success()):
+            succ_seed += 1
+            suc_test_seed_list.append(now_seed)
+        else:
+            now_seed += 1
+            args["render_freq"] = render_freq
+            continue
+
+        args["render_freq"] = render_freq
+
+        TASK_ENV.setup_demo(now_ep_num=now_id, seed=now_seed, is_test=True, **args)
+        episode_info_list = [episode_info["info"]]
+        results = generate_episode_descriptions(args["task_name"], episode_info_list, test_num)
+        instruction = np.random.choice(results[0][instruction_type])
+        TASK_ENV.set_instruction(instruction=instruction)  # set language instruction
+
+        if TASK_ENV.eval_video_path is not None:
+            ffmpeg = subprocess.Popen(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "rawvideo",
+                    "-pixel_format",
+                    "rgb24",
+                    "-video_size",
+                    video_size,
+                    "-framerate",
+                    video_fps,
+                    "-i",
+                    "-",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-vcodec",
+                    "libx264",
+                    "-crf",
+                    "23",
+                    f"{TASK_ENV.eval_video_path}/episode{TASK_ENV.test_num}.mp4",
+                ],
+                stdin=subprocess.PIPE,
+            )
+            TASK_ENV._set_eval_video_ffmpeg(ffmpeg)
+
+        succ = False
+        path_to_pi_model = None
+        if usr_args is not None and "new_ckpt_path" in usr_args:
+            path_to_pi_model = usr_args['new_ckpt_path']
+        ret = model.infer(dict(reset = True, robo_name=usr_args['robo_name'], path_to_pi_model=path_to_pi_model))
+        
+        while TASK_ENV.take_action_cnt<TASK_ENV.step_lim and not succ:
+            observation = TASK_ENV.get_obs()
+            # from IPython import embed;embed()
+            
+            formatted_observation = {
+                "observation.images.cam_high": observation["observation"]["head_camera"]["rgb"], # H,W,3
+                "observation.images.cam_left_wrist": observation["observation"]["left_camera"]["rgb"],
+                "observation.images.cam_right_wrist": observation["observation"]["right_camera"]["rgb"],
+                
+                "observation.state": observation["joint_action"]["vector"],
+                "task": TASK_ENV.get_instruction(),
+            }
+
+            # print(formatted_observation["observation.images.cam_high"].shape)
+            # ========= debug image =========
+            # import torch, torchvision
+            # from PIL import Image
+            # imgs_np = []
+            # for k in ['base_0_rgb', 'left_wrist_0_rgb', 'right_wrist_0_rgb']:
+            #     arr = formatted_observation['image'][k].squeeze(0)  # (H,W,3), uint8
+            #     print(arr.max(), arr.min())
+            #     imgs_np.append(arr)
+
+            # concat = np.concatenate(imgs_np, axis=1)
+            # if TASK_ENV.take_action_cnt % 25 ==0:
+            #     Image.fromarray(concat).save(f'combined_{TASK_ENV.take_action_cnt}.png')
+            # ========= debug image =========
+
+            # from IPython import embed;embed()
+            ret = model.infer(formatted_observation) #(TASK_ENV, model, observation)
+            action, latency = ret['action'], ret['server_timing']
+            if len(action.shape) == 2:
+                initial_obs = False
+                for act in action:
+                    if initial_obs: # ensure the video is correct, but slow down simulation
+                        # observation = TASK_ENV.get_obs()
+                        pass
+                    else:
+                        initial_obs = True
+                    TASK_ENV.take_action(act)
+                    if TASK_ENV.eval_success:
+                        succ = True
+                        break
+            else:
+                TASK_ENV.take_action(action)
+                if TASK_ENV.eval_success:
+                    succ = True
+            
+            print(f"infer time {latency}")
+
+
+        # task_total_reward += TASK_ENV.episode_score
+        if TASK_ENV.eval_video_path is not None:
+            TASK_ENV._del_eval_video_ffmpeg()
+
+        result_tag = "success" if succ else "failure"
+        
+        old_name = f"{TASK_ENV.eval_video_path}/episode{TASK_ENV.test_num}.mp4"
+        new_name = f"{TASK_ENV.eval_video_path}/episode{TASK_ENV.test_num}_{result_tag}.mp4"
+
+        if os.path.exists(old_name):
+            os.rename(old_name, new_name)
+            print(f"Video saved: {new_name}")
+
+
+        if succ:
+            TASK_ENV.suc += 1
+            print("\033[92mSuccess!\033[0m")
+        else:
+            print("\033[91mFail!\033[0m")
+
+        now_id += 1
+        TASK_ENV.close_env(clear_cache=((succ_seed + 1) % clear_cache_freq == 0))
+
+        if TASK_ENV.render_freq:
+            TASK_ENV.viewer.close()
+
+        TASK_ENV.test_num += 1
+
+        print(
+            f"\033[93m{task_name}\033[0m | \033[94m{args['policy_name']}\033[0m | \033[92m{args['task_config']}\033[0m | \033[91m{args['ckpt_setting']}\033[0m\n"
+            f"Success rate: \033[96m{TASK_ENV.suc}/{TASK_ENV.test_num}\033[0m => \033[95m{round(TASK_ENV.suc/TASK_ENV.test_num*100, 1)}%\033[0m, current seed: \033[90m{now_seed}\033[0m\n"
+        )
+        # TASK_ENV._take_picture()
+        now_seed += 1
+
+    return now_seed, TASK_ENV.suc
+
+
+def parse_args_and_config():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--overrides", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    # Parse overrides
+    def parse_override_pairs(pairs):
+        override_dict = {}
+        for i in range(0, len(pairs), 2):
+            key = pairs[i].lstrip("--")
+            value = pairs[i + 1]
+            try:
+                value = eval(value)
+            except:
+                pass
+            override_dict[key] = value
+        return override_dict
+
+    if args.overrides:
+        overrides = parse_override_pairs(args.overrides)
+        config.update(overrides)
+
+    return config
+
+
+if __name__ == "__main__":
+    # from test_render import Sapien_TEST
+    # Sapien_TEST()
+
+    usr_args = parse_args_and_config()
+
+    main(usr_args)

--- a/experiment/robotwin/start_robotwin_infer_and_eval.sh
+++ b/experiment/robotwin/start_robotwin_infer_and_eval.sh
@@ -4,68 +4,93 @@
 # num_per_gpu inference servers stay resident per GPU; sim tasks match
 # inference slots from a queue. Finishing a task frees its slot and starts the next.
 #
-# Usage: bash start_inference_and_eval.sh [options]
-#   --model_path        inference model path (default: <path/to/your/checkpoint>)
+# Usage: bash start_robotwin_infer_and_eval.sh [options]
+#   --model_path        inference model path (default: /path/to/your/checkpoint, or $MODEL_PATH)
 #   --inference_script  inference-side module path (default: deploy/lingbot_vla_v2_policy.py)
 #   --inference_workdir inference-side working dir (default: current working dir)
+#   --eval_workdir      sim-side (RoboTwin repo) working dir (REQUIRED; or $EVAL_WORKDIR; default placeholder /path/to/RoboTwin)
+#   --inference_env     inference-side conda env (default: lingbotvla_open_test, or $INFERENCE_ENV)
+#   --sim_env           sim-side conda env (default: robotwinTest, or $SIM_ENV)
+#   --conda_sh          conda.sh path to source (default: /path/to/miniconda3/etc/profile.d/conda.sh, or $CONDA_SH)
+#   --output_base       result output path (default: /path/to/VLABenchmarkResult, or $OUTPUT_BASE)
 #   --start_port        starting port (default: 9330)
 #   --pid_name          PID file prefix (default: test_pid)
 #   --num_tasks         number of sim tasks, taken in order from the task list (default: 50, max: 50)
-#   --num_gpus          total GPUs (default: 8)
-#   --num_per_gpu       inference servers per GPU (default: 3, i.e. 8*3=24 slots)
+#   --num_gpus          total GPUs (default: 1)
+#   --num_per_gpu       inference servers per GPU (default: 1)
 #   --use_length        chunk length (default: 50)
+#   --robo_name         robot config name (default: robotwin)
+#   --video_fps         video recording fps (default: 10)
+#   --no_video          disable video recording to speed up simulation
 #   --keep_inference    keep inference servers resident after simulation
 #
 # Examples:
-#   bash start_inference_and_eval.sh --num_tasks 50
-#   bash start_inference_and_eval.sh --num_tasks 20 --num_per_gpu 2
+#   bash start_robotwin_infer_and_eval.sh --eval_workdir /path/to/RoboTwin --num_tasks 50 --num_gpus 4 --num_per_gpu 1
+#   bash start_robotwin_infer_and_eval.sh --eval_workdir /path/to/RoboTwin --sim_env RoboTwin --num_tasks 20 --num_per_gpu 2
 # ============================================================
 
 # ===== Parse keyword arguments =====
+export QWEN3VL_PATH="${QWEN3VL_PATH:-/path/to/your/checkpoints/Qwen3-VL-4B-Instruct}"
+
 project_root="$(pwd)"
 inference_workdir="${project_root}/"
 inference_script="deploy/lingbot_vla_v2_policy.py"
-# Override MODEL_PATH / OUTPUT_BASE / QWEN3VL_PATH / EVAL_WORKDIR via env or flags.
 model_path="${MODEL_PATH:-/path/to/your/checkpoint}"
-output_base="${OUTPUT_BASE:-/path/to/your/eval_output}"
+eval_workdir="${EVAL_WORKDIR:-/path/to/RoboTwin}"
+output_base="${OUTPUT_BASE:-/path/to/VLABenchmarkResult}"
+# Conda env names + conda.sh path for both sides (overridable via flags or env).
+inference_env="${INFERENCE_ENV:-lingbotvla}"
+sim_env="${SIM_ENV:-RoboTwin}"
+conda_sh="${CONDA_SH:-/path/to/miniconda3/etc/profile.d/conda.sh}"
 start_port=9330
 pid_name="test_pid"
 num_tasks=50
-num_gpus=8
-num_per_gpu=3
+num_gpus=1
+num_per_gpu=1
 use_length=50
 robo_name="robotwin"
 video_fps=10
-enable_video=False
+enable_video=True
+keep_inference=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --model_path)      model_path="$2";      shift 2 ;;
-        --inference_script) inference_script="$2"; shift 2 ;;
         --inference_workdir) inference_workdir="$2"; shift 2 ;;
-        --output_base)     output_base="$2";     shift 2 ;;
-        --start_port)      start_port="$2";      shift 2 ;;
-        --pid_name)        pid_name="$2";        shift 2 ;;
-        --num_tasks)       num_tasks="$2";       shift 2 ;;
-        --num_gpus)        num_gpus="$2";        shift 2 ;;
-        --num_per_gpu)     num_per_gpu="$2";     shift 2 ;;
-        --use_length)      use_length="$2";      shift 2 ;;
-        --robo_name)       robo_name="$2";       shift 2 ;;
-        --video_fps)       video_fps="$2";       shift 2 ;;
-        --no_video)        enable_video=False;   shift ;;
+        --inference_script)  inference_script="$2";  shift 2 ;;
+        --model_path)        model_path="$2";        shift 2 ;;
+        --eval_workdir)      eval_workdir="$2";      shift 2 ;;
+        --output_base)       output_base="$2";       shift 2 ;;
+        --start_port)        start_port="$2";        shift 2 ;;
+        --pid_name)          pid_name="$2";          shift 2 ;;
+        --num_tasks)         num_tasks="$2";         shift 2 ;;
+        --num_gpus)          num_gpus="$2";          shift 2 ;;
+        --num_per_gpu)       num_per_gpu="$2";       shift 2 ;;
+        --use_length)        use_length="$2";        shift 2 ;;
+        --robo_name)         robo_name="$2";         shift 2 ;;
+        --video_fps)         video_fps="$2";         shift 2 ;;
+        --no_video)          enable_video=False;     shift ;;
+        --keep_inference)    keep_inference=true;    shift ;;
+        --inference_env)     inference_env="$2";     shift 2 ;;
+        --sim_env)           sim_env="$2";           shift 2 ;;
+        --conda_sh)          conda_sh="$2";          shift 2 ;;
         -h|--help)
             echo "Usage: bash $0 [options]"
             echo "  --model_path        inference model path"
             echo "  --inference_script  inference-side module path"
             echo "  --inference_workdir inference-side working dir"
+            echo "  --eval_workdir      sim-side (RoboTwin repo) working dir (REQUIRED; or \$EVAL_WORKDIR)"
+            echo "  --inference_env     inference-side conda env (default: lingbotvla, or \$INFERENCE_ENV)"
+            echo "  --sim_env           sim-side conda env (default: RoboTwin, or \$SIM_ENV)"
+            echo "  --conda_sh          conda.sh path to source (default: /path/to/miniconda3/etc/profile.d/conda.sh, or \$CONDA_SH)"
             echo "  --output_base       result output path"
             echo "  --start_port        starting port (default: 9330)"
             echo "  --pid_name          PID file prefix (default: test_pid)"
             echo "  --num_tasks         number of sim tasks (default: 50, max: 50)"
-            echo "  --num_gpus          total GPUs (default: 8)"
-            echo "  --num_per_gpu       inference servers per GPU (default: 3)"
+            echo "  --num_gpus          total GPUs (default: 1)"
+            echo "  --num_per_gpu       inference servers per GPU (default: 1)"
             echo "  --use_length        chunk length (default: 50)"
-            echo "  --robo_name         robot config name (default: robotwin_clean_and_aug)"
+            echo "  --robo_name         robot config name (default: robotwin)"
+            echo "  --keep_inference    keep inference servers resident after simulation"
             echo "  --video_fps         video recording fps (default: 10)"
             echo "  --no_video          disable video recording to speed up simulation"
             exit 0 ;;
@@ -74,21 +99,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# ===== Fix Vulkan ICD (required by Sapien rendering) =====
-# nvidia_icd="/etc/vulkan/icd.d/nvidia_icd.json"
-# echo -e "\033[33mWriting NVIDIA Vulkan ICD config: ${nvidia_icd}\033[0m"
-# mkdir -p "$(dirname "$nvidia_icd")"
-# cat > "$nvidia_icd" << 'VULKAN_EOF'
-# {
-#     "file_format_version" : "1.0.0",
-#     "ICD": {
-#         "library_path": "/usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.0",
-#         "api_version" : "1.3"
-#     }
-# }
-# VULKAN_EOF
-# export VK_ICD_FILENAMES="$nvidia_icd"
-# export __EGL_VENDOR_LIBRARY_FILENAMES="/usr/share/glvnd/egl_vendor.d/10_nvidia.json"
 
 # ===== Common environment =====
 # Cleanup: kill all child processes on exit / Ctrl-C / kill
@@ -125,18 +135,45 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-export QWEN3VL_PATH="${QWEN3VL_PATH:-/path/to/your/checkpoints/Qwen3-VL-4B-Instruct}"
 
-# ===== Working dir =====
-eval_workdir="${EVAL_WORKDIR:-/path/to/Robotwin}"
 
-# ===== Sim-side python =====
-# The sim side runs with the current shell's Python environment.
-if ! command -v python >/dev/null 2>&1; then
-    echo -e "\033[31mError: python command not found for sim side\033[0m"
+# ===== Working dir (RoboTwin sim side) -- REQUIRED =====
+# Must be supplied via --eval_workdir flag or $EVAL_WORKDIR env. No default.
+if [ -z "$eval_workdir" ]; then
+    eval_workdir="${EVAL_WORKDIR:-}"
+fi
+if [ -z "$eval_workdir" ]; then
+    echo -e "\033[31mError: --eval_workdir (or \$EVAL_WORKDIR) is required (the RoboTwin repo root).\033[0m"
     exit 1
 fi
-echo -e "\033[36mSim-side python: $(command -v python) ($(python --version 2>&1))\033[0m"
+if [ ! -d "$eval_workdir" ]; then
+    echo -e "\033[31mError: sim workdir '${eval_workdir}' not found.\033[0m"
+    echo "  Pass --eval_workdir <path> or set EVAL_WORKDIR=<path> (the RoboTwin repo root)."
+    exit 1
+fi
+echo -e "\033[36mSim workdir: ${eval_workdir}\033[0m"
+
+# ===== Sim-side python (conda env: ${sim_env}) =====
+# conda_sh / sim_env / inference_env are resolved above (flag > env > builtin default).
+if [ ! -f "$conda_sh" ]; then
+    echo -e "\033[31mError: conda profile not found at ${conda_sh}\033[0m"
+    exit 1
+fi
+# shellcheck disable=SC1090
+source "$conda_sh"
+if ! conda activate "$sim_env" 2>/dev/null; then
+    echo -e "\033[31mError: conda env '${sim_env}' not found; create it first\033[0m"
+    exit 1
+fi
+if ! command -v python >/dev/null 2>&1; then
+    echo -e "\033[31mError: python command not found in conda env '${sim_env}'\033[0m"
+    exit 1
+fi
+sim_python="$(command -v python)"
+echo -e "\033[36mSim-side python (${sim_env}): ${sim_python} ($(${sim_python} --version 2>&1))\033[0m"
+# Deactivate so later phases don't inherit sim env; the actual sim launch
+# activates ${sim_env} itself via `setsid bash -c`.
+conda deactivate 2>/dev/null || true
 
 # ===== Task count validation =====
 if [ "$num_tasks" -gt 50 ]; then
@@ -216,10 +253,10 @@ for slot in $(seq 0 $((num_slots-1))); do
         inference_script_for_module="${inference_script_for_module#${inference_workdir%/}/}"
     fi
     inference_module=$(echo "${inference_script_for_module}" | sed 's|/|.|g; s|\.py$||')
-    setsid python -m ${inference_module} \
-        --model_path "${model_path}" \
-        --use_length "${use_length}" \
-        --port "${port}" > "$log_file" 2>&1 &
+    setsid bash -c "source ${conda_sh} && conda activate ${inference_env} && SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 python -m ${inference_module} \
+        --model_path '${model_path}' \
+        --use_length '${use_length}' \
+        --port '${port}'" > "$log_file" 2>&1 &
 
     pid=$!
     echo "${pid}" >> "$inference_pid_file"
@@ -247,6 +284,64 @@ active_inference=$num_slots
 echo -e "\033[32m========== Starting sim side (queue-scheduled, ${num_slots} concurrent slots) ==========\033[0m"
 
 cd "$eval_workdir" || { echo -e "\033[31mError: sim workdir ${eval_workdir} missing\033[0m"; exit 1; }
+
+# ===== Ensure the lingbot eval client is present under RoboTwin/script =====
+# The eval client resolves its ../task_config relative to its own location, so it
+# must live at <RoboTwin>/script/ for _camera_config.yml to be found.
+eval_client_src="${inference_workdir}experiment/robotwin/eval_policy_client_lingbotvla.py"
+eval_client_dst="${eval_workdir}/script/eval_policy_client_lingbotvla.py"
+if [ ! -f "$eval_client_dst" ]; then
+    if [ ! -f "$eval_client_src" ]; then
+        echo -e "\033[31mError: eval client source not found: ${eval_client_src}\033[0m"
+        exit 1
+    fi
+    echo -e "\033[36mCopying eval client -> ${eval_client_dst}\033[0m"
+    cp "$eval_client_src" "$eval_client_dst"
+fi
+
+# ===== Ensure the deploy client helpers are present under RoboTwin/script/deploy =====
+# The eval client does `from script.deploy.websocket_client_policy import WebsocketClientPolicy`,
+# which pulls in a sibling msgpack_numpy. Copy any that are missing from the inference repo.
+deploy_pkg_src="${inference_workdir}deploy"
+deploy_pkg_dst="${eval_workdir}/script/deploy"
+mkdir -p "$deploy_pkg_dst"
+for f in __init__.py websocket_client_policy.py msgpack_numpy.py; do
+    if [ ! -f "$deploy_pkg_dst/$f" ]; then
+        if [ ! -f "$deploy_pkg_src/$f" ]; then
+            echo -e "\033[31mError: deploy helper source not found: ${deploy_pkg_src}/${f}\033[0m"
+            exit 1
+        fi
+        echo -e "\033[36mCopying deploy helper -> ${deploy_pkg_dst}/${f}\033[0m"
+        cp "$deploy_pkg_src/$f" "$deploy_pkg_dst/$f"
+    fi
+done
+
+# ===== Ensure curobo absolute paths point at this RoboTwin checkout =====
+# Two artifacts embed absolute paths and go stale when RoboTwin is moved to a
+# new directory (both would break the curobo planner at sim start):
+#   (1) assets/embodiments/*/curobo*.yml -- urdf_path / collision_spheres
+#       (regenerated from *_tmp.yml templates via script/update_embodiment_config_path.py)
+#   (2) the editable-install .pth in the RoboTwin conda env pointing at envs/curobo/src
+# Both checks are idempotent: only act when the embedded path != current location.
+_eval_resolved="$(pwd -P)"   # physical path of this RoboTwin checkout (after cd)
+_rep_yml="assets/embodiments/aloha-agilex/curobo_left.yml"
+if [ -f "$_rep_yml" ] && ! grep -qF "${_eval_resolved}/assets" "$_rep_yml" 2>/dev/null; then
+    echo -e "\033[36mCurobo yml paths stale -> regenerating for ${_eval_resolved}\033[0m"
+    ( source ${conda_sh} && conda activate ${sim_env} \
+      && python script/update_embodiment_config_path.py ) \
+      || { echo -e "\033[31mError: curobo path regeneration failed\033[0m"; exit 1; }
+fi
+_env_site="$( source ${conda_sh} && conda activate ${sim_env} \
+    && python -c 'import site;print(site.getsitepackages()[0])' )"
+_curobo_pth="$(echo "${_env_site}"/__editable__.nvidia_curobo-*.pth)"
+_expected_curobo_src="${_eval_resolved}/envs/curobo/src"
+if [ -f "$_curobo_pth" ]; then
+    _cur_curobo_src="$(grep -v '^[[:space:]]*#' "$_curobo_pth" | head -1)"
+    if [ "$_cur_curobo_src" != "$_expected_curobo_src" ]; then
+        echo -e "\033[36mCurobo editable .pth stale (${_cur_curobo_src}) -> ${_expected_curobo_src}\033[0m"
+        echo "$_expected_curobo_src" > "$_curobo_pth"
+    fi
+fi
 
 total_start_time=$(date +%s)
 
@@ -297,11 +392,16 @@ launch_task() {
         echo "================================================================"
     } >> "$log_file"
 
+    # Prepend the RoboTwin env's site-packages to PYTHONPATH (set inside the
+    # bash -c after `conda activate`) so the env's numpy 1.26.4 -- which mplib /
+    # sapien / open3d were compiled against -- is used instead of ~/.local's
+    # numpy 2.x. The user-site numpy 2.x otherwise shadows it and segfaults
+    # mplib's convert_physx_component during planner init.
     PYTHONUNBUFFERED=1 \
     PYTHONWARNINGS=ignore::UserWarning \
     XLA_PYTHON_CLIENT_MEM_FRACTION=0.9 \
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 \
-    setsid python -u script/eval_polict_client_openpi.py --config policy/$policy_name/deploy_policy.yml \
+    setsid bash -c "source ${conda_sh} && conda activate ${sim_env} && export PYTHONPATH=\"\$(python -c 'import site;print(site.getsitepackages()[0])')\${PYTHONPATH:+:\$PYTHONPATH}\" && PYTHONUNBUFFERED=1 PYTHONWARNINGS=ignore::UserWarning XLA_PYTHON_CLIENT_MEM_FRACTION=0.9 SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 python -u ${eval_client_dst} --config policy/${policy_name}/deploy_policy.yml \
         --overrides \
         --task_name ${task_name} \
         --task_config ${task_config} \
@@ -312,7 +412,7 @@ launch_task() {
         --robo_name ${robo_name} \
         --video_fps ${video_fps} \
         --eval_video_log ${enable_video} \
-        --output_dir "${run_dir}/eval_results" >> "$log_file" 2>&1 &
+        --output_dir '${run_dir}/eval_results'" >> "$log_file" 2>&1 &
 
     local pid=$!
     echo "${pid}" >> "$eval_pid_file"


### PR DESCRIPTION
…l client & README

- start_robotwin_infer_and_eval.sh:
  - expose interfaces (flag > env > default): --eval_workdir (required), --inference_env/--sim_env/--conda_sh, --model_path/--output_base, QWEN3VL_PATH
  - replace all machine-specific path defaults with /path/to/xxx placeholders
  - both sides launched in their own conda env via setsid bash -c
  - prepend sim env site-packages to PYTHONPATH (fix mplib segfault from user-site numpy 2.x shadowing env numpy 1.26.x)
  - eval client + deploy helpers auto-copied from inference repo to <RoboTwin>/script[/(deploy)] on first run
  - self-heal curobo embodiment .yml paths and editable-install .pth to current RoboTwin physical path (idempotent, pwd -P)
  - fix undefined inference_workdirscript -> inference_workdir
  - add keep_inference default + flag; sync --help & top usage comment
- experiment/robotwin/eval_policy_client_lingbotvla.py: lingbot VLA sim eval client
- experiment/robotwin/README.md: add "Simulated Evaluation" how-to section